### PR TITLE
Updated styling and button enabling/disabling

### DIFF
--- a/script/controllers/GameController.js
+++ b/script/controllers/GameController.js
@@ -218,6 +218,8 @@ class GameController {
         
         // Animation logic for shuffling
         this.animateShuffle(allCards, event, callback);
+
+        // Re-enable buttons
     }
     
     /**
@@ -303,6 +305,7 @@ class GameController {
             setTimeout(() => {
                 this.performShuffle(callback);
             }, alignDuration);
+            this.setAllButtonStates(ENABLE, ENABLE, ENABLE, ENABLE, ENABLE, ENABLE);
         }, returnTime);
         
     }
@@ -347,8 +350,6 @@ class GameController {
         // Re-arrange cards in stack
         this.arrangeCardsInStack();
         
-        // Re-enable buttons
-        this.setAllButtonStates(ENABLE, ENABLE, ENABLE, ENABLE, ENABLE, ENABLE);
         
         // Call callback if provided
         this.executeCallback(callback);
@@ -360,7 +361,7 @@ class GameController {
      */
     dealCardToHand(target) {
         // Disable buttons during animation
-        this.setAllButtonStates(true, true, true, true);
+        this.setAllButtonStates(DISABLE, DISABLE, DISABLE, DISABLE, DISABLE, DISABLE);
         
         // Get the top card from deck
         const cardToDeal = this.systemView.getTopCard();
@@ -420,6 +421,7 @@ class GameController {
                     
                     // Re-enable buttons only if player hasn't busted
                     this.playerView.setGameActionButtonsState(ENABLE, ENABLE);
+                    this.setAllButtonStates(ENABLE, ENABLE, ENABLE, ENABLE, ENABLE, ENABLE);
                 }, 300);
             }
         });
@@ -432,7 +434,7 @@ class GameController {
         console.log("Reset button clicked");
         
         // Disable buttons during operation
-        this.setAllButtonStates(true, true, true, true);
+        this.setAllButtonStates(true, true, true, true, true, true);
         
         // Get cards from both hands
         const dealerCards = this.playerView.getHandCards('dealer');
@@ -466,7 +468,7 @@ class GameController {
             this.updateCounters();
             
             // Re-enable buttons
-            this.setAllButtonStates(false, false, false, false);
+            this.setAllButtonStates(false, false, false, false, false, false);
             
             // Shuffle the deck
             this.shuffleDeck();
@@ -489,7 +491,7 @@ class GameController {
         console.log("Starting new game...");
         
         // Disable all game buttons during new game setup
-        this.setAllButtonStates(false, true, true, true, true, true);
+        this.setAllButtonStates(true, true, true, true, true, true);
         
         // Check if enough cards in deck
         if (this.systemModel.getDeckCount() < 4) {
@@ -498,13 +500,13 @@ class GameController {
             this.playerView.setPlayerButtonsState(false);
             return;
         }
-        
+
+        // Clear hands
+        this.handleReset();
+
         // Start new game in models
         this.systemModel.startNewGame();
         this.playerModel.setPlayerTurn(true);
-        
-        // Clear hands
-        this.clearHands();
         
         // Shuffle and deal initial cards
         this.systemView.adminButtons.shuffle.shuffleCallback = () => this.dealInitialCards();

--- a/script/controllers/GameController.js
+++ b/script/controllers/GameController.js
@@ -218,8 +218,6 @@ class GameController {
         
         // Animation logic for shuffling
         this.animateShuffle(allCards, event, callback);
-
-        // Re-enable buttons
     }
     
     /**
@@ -305,7 +303,6 @@ class GameController {
             setTimeout(() => {
                 this.performShuffle(callback);
             }, alignDuration);
-            this.setAllButtonStates(ENABLE, ENABLE, ENABLE, ENABLE, ENABLE, ENABLE);
         }, returnTime);
         
     }
@@ -405,7 +402,7 @@ class GameController {
             this.updateCounters();
             
             // Re-enable buttons
-            this.setAllButtonStates(false, false, false, false);
+            this.setAllButtonStates(false, false, false, true, false, false);
             
             if (target === 'player') {
                 setTimeout(() => {
@@ -421,7 +418,7 @@ class GameController {
                     
                     // Re-enable buttons only if player hasn't busted
                     this.playerView.setGameActionButtonsState(ENABLE, ENABLE);
-                    this.setAllButtonStates(ENABLE, ENABLE, ENABLE, ENABLE, ENABLE, ENABLE);
+                    this.setAllButtonStates(ENABLE, ENABLE, ENABLE, DISABLE, ENABLE, ENABLE);
                 }, 300);
             }
         });
@@ -432,17 +429,14 @@ class GameController {
      */
     handleReset(callback) {
         console.log("Reset button clicked");
-        
-        // Disable buttons during operation
-        this.setAllButtonStates(true, true, true, true, true, true);
-        
+
         // Get cards from both hands
         const dealerCards = this.playerView.getHandCards('dealer');
         const playerCards = this.playerView.getHandCards('player');
         
         // If no cards in hands, nothing to reset
         if (dealerCards.length === 0 && playerCards.length === 0) {
-            this.setAllButtonStates(false, false, false, false);
+            this.setAllButtonStates(false, false, false, true, true, true);
             this.shuffleDeck(callback);  // call shuffle logic even if nothing was reset
             return;
         }

--- a/script/controllers/GameController.js
+++ b/script/controllers/GameController.js
@@ -430,7 +430,7 @@ class GameController {
     /**
      * Handle reset button click
      */
-    handleReset() {
+    handleReset(callback) {
         console.log("Reset button clicked");
         
         // Disable buttons during operation
@@ -443,6 +443,7 @@ class GameController {
         // If no cards in hands, nothing to reset
         if (dealerCards.length === 0 && playerCards.length === 0) {
             this.setAllButtonStates(false, false, false, false);
+            this.shuffleDeck(callback);  // call shuffle logic even if nothing was reset
             return;
         }
         
@@ -471,7 +472,7 @@ class GameController {
             this.setAllButtonStates(false, false, false, false, false, false);
             
             // Shuffle the deck
-            this.shuffleDeck();
+            this.shuffleDeck(callback);
         }, 600);
     }
     
@@ -501,16 +502,12 @@ class GameController {
             return;
         }
 
-        // Clear hands
-        this.handleReset();
-
         // Start new game in models
         this.systemModel.startNewGame();
         this.playerModel.setPlayerTurn(true);
-        
-        // Shuffle and deal initial cards
-        this.systemView.adminButtons.shuffle.shuffleCallback = () => this.dealInitialCards();
-        this.systemView.adminButtons.shuffle.click();
+
+        // Clear hands + shuffle and deal initial cards
+        this.handleReset(() => this.dealInitialCards());
     }
     
     /**

--- a/style/kayla-base.css
+++ b/style/kayla-base.css
@@ -38,7 +38,7 @@ h1::after {
     flex-wrap: nowrap;
     justify-content: center;
     gap: 0;
-    min-height: 150px;
+    min-height: 210px;
     margin-bottom: 50px;
     padding: 30px 60px;
     background-color: #6F4E37;


### PR DESCRIPTION
Fixes user and dealer card deck so when the first card is dealt, the decks do not expand. "New Game", "Hit", and "Stay" buttons are correctly enabled/disabled when playing a round to prevent misuse.