### PR TITLE
feat: button functions corrected

### DIFF
--- a/script/controllers/GameController.js
+++ b/script/controllers/GameController.js
@@ -347,9 +347,6 @@ class GameController {
         // Re-arrange cards in stack
         this.arrangeCardsInStack();
         
-        // Re-enable buttons
-        this.setAllButtonStates(ENABLE, ENABLE, ENABLE, ENABLE, ENABLE, ENABLE);
-        
         // Call callback if provided
         this.executeCallback(callback);
     }


### PR DESCRIPTION
New Game is only active when a game is not in progress. Hit and stand are only active when its the user's turn. No buttons are active when an animation is occuring to prevent breakages.

closes #61  

